### PR TITLE
Allow the defined-types-are-used rule to be disabled

### DIFF
--- a/lib/lint-directive.js
+++ b/lib/lint-directive.js
@@ -3,9 +3,38 @@ module.exports = { LintDirective };
 function LintDirective(context) {
   const disabledStack = [new Set()];
 
+  /** 
+   * Because the "defined-types-are-used" rule's error is thrown on the 
+   * GraphQL document, the rule won't be present in the disabledStack. 
+   * Hence we have to look at the node that caused the error and check that
+   * it contains the disable rule
+  **/
+  const definedTypesAreUsedIsDisabled = function(err) {
+    // Find the lint directive
+    const lintDirective = err.nodes[0].directives.find(
+      directive => directive.name.value === 'lint'
+    );
+
+    if (!lintDirective) return false;
+
+    // Find the disable argument
+    const disableArgument = lintDirective.arguments.find(
+      argument => argument.name && argument.name.value === 'disable'
+    );
+
+    if (!disableArgument) return false;
+
+    // Return true if the 'defined-types-are-used' rule is present
+    return disableArgument.value.values && disableArgument.value.values.find(
+      stringValue => stringValue.value === 'defined-types-are-used'
+    );
+  };
+
   const originalReportError = context.reportError;
   context.reportError = function(err) {
-    if (!disabledStack[disabledStack.length - 1].has(err.ruleName)) {
+    if (!(disabledStack[disabledStack.length - 1].has(err.ruleName) || 
+        err.ruleName === "defined-types-are-used" && definedTypesAreUsedIsDisabled(err))) 
+    {
       return originalReportError.apply(this, arguments);
     }
   };

--- a/test/schema.gql
+++ b/test/schema.gql
@@ -13,3 +13,8 @@ type Nested @lint(disable: ["fields-have-descriptions", "not-all-fields-null"]) 
   foo: String
   bar: String @lint(enable: ["fields-have-descriptions"])
 }
+
+type Unused @lint(disable: ["types-have-descriptions", "defined-types-are-used"]) {
+  "sample description"
+  foo: String!
+}


### PR DESCRIPTION
When we have a 'defined-types-are-used' error thrown, check the node which caused the error for the disable 'defined-types-are-used' rule